### PR TITLE
TECH-592: Update supported devices section to reflect Jetson Orin Nano DevKit

### DIFF
--- a/src/content/docs/1-getting-started/4-device-setup.mdx
+++ b/src/content/docs/1-getting-started/4-device-setup.mdx
@@ -40,6 +40,14 @@ The table below shows what each device type supports and whether it's suitable f
       <td align="center">✅</td>
     </tr>
     <tr>
+      <td>Jetson Orin Nano DevKit</td>
+      <td align="center">✅</td>
+      <td align="center">✅</td>
+      <td align="center">✅</td>
+      <td align="center">❌</td>
+      <td align="center">✅</td>
+    </tr>
+    <tr>
       <td>Samsung Tizen TV</td>
       <td align="center">❌</td>
       <td align="center">✅</td>
@@ -118,6 +126,10 @@ Intel devices and ARM-based Giada DN74 are ideal for production deployments wher
 - **Versatile deployment** — Use as edge computing devices, interactive kiosks, or complete user experiences
 - **Hardware acceleration** — Devices with CUDA-compatible GPUs can run AI models with hardware acceleration
 - **Production ready** — Suitable for on-site, enterprise deployments
+
+#### Nvidia Jetson Orin Nano
+
+The Nvidia Jetson Orin Nano is ideal for advanced AI workloads and development. PhyOS supports the NVIDIA Jetson Orin Nano DevKit (P3767-0005 8GB module on P3768-0000 reference carrier). PhyOS images for Jetson include the CUDA runtime and libraries pre-configured, allowing developers to focus on building applications with a streamlined setup experience rather than dealing with complex CUDA installation and configuration processes. This device is perfect for AI development, prototyping, and testing advanced edge computing scenarios.
 
 ### 📺 Samsung Tizen TVs
 

--- a/src/content/docs/1-getting-started/4-device-setup.mdx
+++ b/src/content/docs/1-getting-started/4-device-setup.mdx
@@ -129,7 +129,7 @@ Intel devices and ARM-based Giada DN74 are ideal for production deployments wher
 
 #### Nvidia Jetson Orin Nano
 
-The Nvidia Jetson Orin Nano is ideal for advanced AI workloads and development. PhyOS supports the NVIDIA Jetson Orin Nano DevKit (P3767-0005 8GB module on P3768-0000 reference carrier). PhyOS images for Jetson include the CUDA runtime and libraries pre-configured, allowing developers to focus on building applications with a streamlined setup experience rather than dealing with complex CUDA installation and configuration processes. This device is perfect for AI development, prototyping, and testing advanced edge computing scenarios.
+The NVIDIA Jetson Orin Nano is ideal for advanced AI workloads and applications. PhyOS supports the NVIDIA Jetson Orin Nano DevKit (P3767-0005 8GB module on the P3768-0000 reference carrier). PhyOS images for Jetson include the CUDA runtime preconfigured and hardware-accelerated video playback support, allowing developers to focus on building applications with a streamlined setup experience rather than dealing with complex configuration processes. This device is perfect for AI development, prototyping, and testing advanced edge computing scenarios.
 
 ### 📺 Samsung Tizen TVs
 


### PR DESCRIPTION
**Issue**: TECH-592

**Description**: Updated build-phygrid documentation to include support for the Jetson Orin Nano DevKit in the supported devices table and added detailed information about its capabilities for AI workloads.

**Changes Made**: 
- Added Jetson Orin Nano DevKit to supported devices table with same capabilities as Giada DN74 but not suitable for production use
- Added Nvidia Jetson Orin Nano subsection under Intel x86-64 and ARM-based Hardware describing its AI capabilities and CUDA runtime support

**Breaking Changes**: None

**Testing**: 
- Verified documentation formatting with yarn format
- Confirmed successful Gatsby build with yarn build  
- Validated MDX compilation and page generation

**Dependencies/Notes**: 
- New content integrates seamlessly with existing documentation structure
- Jetson Orin Nano DevKit positioned as development-focused device ideal for AI workloads
- Emphasizes streamlined CUDA setup experience provided by PhyOS images

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>